### PR TITLE
Revert "Bump to Version 3.2.0"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,3 @@
-3.2.0 - 2020-07-30
-==================
-
-### Features
-- `debug-statements`: add support for `pydevd_pycharm` debugger
-    - #502 PR by @jgeerds.
-
-### Fixes
-- `check-executables-have-shebangs`: fix git-quoted files on windows (spaces,
-  non-ascii, etc.)
-    - #509 PR by @pawamoy.
-    - #508 issue by @pawamoy.
-
 3.1.0 - 2020-05-20
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add this to your `.pre-commit-config.yaml`
 
 ```yaml
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0  # Use the ref you want to point at
+    rev: v3.1.0  # Use the ref you want to point at
     hooks:
     -   id: trailing-whitespace
     # -   id: ...

--- a/pre_commit_hooks/check_executables_have_shebangs.py
+++ b/pre_commit_hooks/check_executables_have_shebangs.py
@@ -12,14 +12,6 @@ from pre_commit_hooks.util import cmd_output
 EXECUTABLE_VALUES = frozenset(('1', '3', '5', '7'))
 
 
-def zsplit(s: str) -> List[str]:
-    s = s.strip('\0')
-    if s:
-        return s.split('\0')
-    else:
-        return []
-
-
 def check_executables(paths: List[str]) -> int:
     if sys.platform == 'win32':  # pragma: win32 cover
         return _check_git_filemode(paths)
@@ -34,9 +26,9 @@ def check_executables(paths: List[str]) -> int:
 
 
 def _check_git_filemode(paths: Sequence[str]) -> int:
-    outs = cmd_output('git', 'ls-files', '-z', '--stage', '--', *paths)
+    outs = cmd_output('git', 'ls-files', '--stage', '--', *paths)
     seen: Set[str] = set()
-    for out in zsplit(outs):
+    for out in outs.splitlines():
         metadata, path = out.split('\t')
         tagmode = metadata.split(' ', 1)[0]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pre_commit_hooks
-version = 3.2.0
+version = 3.1.0
 description = Some out-of-the-box hooks for pre-commit.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/check_executables_have_shebangs_test.py
+++ b/tests/check_executables_have_shebangs_test.py
@@ -73,21 +73,6 @@ def test_check_git_filemode_passing(tmpdir):
         assert check_executables_have_shebangs._check_git_filemode(files) == 0
 
 
-def test_check_git_filemode_passing_unusual_characters(tmpdir):
-    with tmpdir.as_cwd():
-        cmd_output('git', 'init', '.')
-
-        f = tmpdir.join('mañana.txt')
-        f.write('#!/usr/bin/env bash')
-        f_path = str(f)
-        cmd_output('chmod', '+x', f_path)
-        cmd_output('git', 'add', f_path)
-        cmd_output('git', 'update-index', '--chmod=+x', f_path)
-
-        files = (f_path,)
-        assert check_executables_have_shebangs._check_git_filemode(files) == 0
-
-
 def test_check_git_filemode_failing(tmpdir):
     with tmpdir.as_cwd():
         cmd_output('git', 'init', '.')
@@ -100,16 +85,6 @@ def test_check_git_filemode_failing(tmpdir):
 
         files = (f_path,)
         assert check_executables_have_shebangs._check_git_filemode(files) == 1
-
-
-@pytest.mark.parametrize('out', ('\0f1\0f2\0', '\0f1\0f2', 'f1\0f2\0'))
-def test_check_zsplits_correctly(out):
-    assert check_executables_have_shebangs.zsplit(out) == ['f1', 'f2']
-
-
-@pytest.mark.parametrize('out', ('\0\0', '\0', ''))
-def test_check_zsplit_returns_empty(out):
-    assert check_executables_have_shebangs.zsplit(out) == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Reverts syncier/pre-commit-hooks-1#1

Really needs to be automated during the fact that there is also a release or version tag missing after merge. Therefore we should rollback and invest more time. 